### PR TITLE
LUT-27394 : Add Jersey exception mapper

### DIFF
--- a/src/java/fr/paris/lutece/plugins/rest/business/resourceinfo/AbstractResourceInfo.java
+++ b/src/java/fr/paris/lutece/plugins/rest/business/resourceinfo/AbstractResourceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/business/resourceinfo/IResourceInfo.java
+++ b/src/java/fr/paris/lutece/plugins/rest/business/resourceinfo/IResourceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/business/resourceinfo/ResourceInfo.java
+++ b/src/java/fr/paris/lutece/plugins/rest/business/resourceinfo/ResourceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/LuteceApplicationResourceConfig.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/LuteceApplicationResourceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.rest.service;
 
+import fr.paris.lutece.plugins.rest.service.mapper.UncaughtJerseyExceptionMapper;
 import fr.paris.lutece.plugins.rest.service.mapper.UncaughtThrowableMapper;
 import fr.paris.lutece.plugins.rest.service.mediatype.MediaTypeMapping;
 import fr.paris.lutece.plugins.rest.service.mediatype.RestMediaTypes;
@@ -66,6 +67,7 @@ public class LuteceApplicationResourceConfig extends ResourceConfig
             // Registering JacksonFeature without its built-in ExceptionMapper so that we can register our own generic one
             register( JacksonFeature.withoutExceptionMappers( ) );
             register( new UncaughtThrowableMapper( ) );
+            register( new UncaughtJerseyExceptionMapper( ) );
         }
 
         // Automatically register all beans with @Path annotation because

--- a/src/java/fr/paris/lutece/plugins/rest/service/LuteceJerseySpringServlet.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/LuteceJerseySpringServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/LuteceJerseySpringWebApplicationInitializer.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/LuteceJerseySpringWebApplicationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/RestConstants.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/RestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/formatters/IFormatter.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/formatters/IFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/mapper/GenericUncaughtExceptionMapper.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/mapper/GenericUncaughtExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/mapper/GenericUncaughtJerseyExceptionMapper.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/mapper/GenericUncaughtJerseyExceptionMapper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2024, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.rest.service.mapper;
+
+import fr.paris.lutece.portal.service.util.AppLogService;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Generic Jersey exception mapper, implementing {@link ExceptionMapper}, used to convert uncaught Jersey exceptions to a proper {@link Response} to
+ * return.<br/>
+ * To implement your own in a Lutece plugin or module using lutece-rest-plugin-rest, extend this class, annotate it with {@link javax.ws.rs.ext.Provider}, and
+ * add it as a bean in the context.xml file.
+ *
+ * @param <T>
+ *            The sub-class of {@link WebApplicationException} to catch
+ * @param <E>
+ *            The entity type wanted in the {@link Response}
+ */
+public abstract class GenericUncaughtJerseyExceptionMapper<T extends WebApplicationException, E> implements ExceptionMapper<T>
+{
+    @Override
+    public Response toResponse( final T exception )
+    {
+        AppLogService.error( "REST : Uncaught Jersey exception occured.", exception );
+        final Response exResponse = exception.getResponse( );
+        return Response.status( exResponse.getStatus( ) ).entity( this.buildEntity( exception ) ).type( exResponse.getMediaType( ) ).build( );
+    }
+
+    protected abstract E buildEntity( final T exception );
+}

--- a/src/java/fr/paris/lutece/plugins/rest/service/mapper/UncaughtJerseyExceptionMapper.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/mapper/UncaughtJerseyExceptionMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2024, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.rest.service.mapper;
+
+import javax.ws.rs.WebApplicationException;
+
+/**
+ * Exception mapper designed to intercept uncaught {@link WebApplicationException}.<br/>
+ * This is the default mapper for Jersey exceptions, it will only be triggered if no better suitable mappers are available for the fired exception.
+ *
+ * @see GenericUncaughtJerseyExceptionMapper
+ */
+public class UncaughtJerseyExceptionMapper extends GenericUncaughtJerseyExceptionMapper<WebApplicationException, String>
+{
+    @Override
+    protected String buildEntity( final WebApplicationException exception )
+    {
+        return exception.getMessage( );
+    }
+}

--- a/src/java/fr/paris/lutece/plugins/rest/service/mapper/UncaughtThrowableMapper.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/mapper/UncaughtThrowableMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/mediatype/MediaTypeMapping.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/mediatype/MediaTypeMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/mediatype/RestMediaTypes.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/mediatype/RestMediaTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/param/AbstractParam.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/param/AbstractParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/resourceinfo/AbstractResourceInfoProvider.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/resourceinfo/AbstractResourceInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/resourceinfo/IResourceInfoProvider.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/resourceinfo/IResourceInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/resourceinfo/ResourceInfoManager.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/resourceinfo/ResourceInfoManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/service/writers/AbstractWriter.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/writers/AbstractWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/util/json/JSONUtil.java
+++ b/src/java/fr/paris/lutece/plugins/rest/util/json/JSONUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/java/fr/paris/lutece/plugins/rest/util/xml/XMLUtil.java
+++ b/src/java/fr/paris/lutece/plugins/rest/util/xml/XMLUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Ajout d'un mapper pour intercepter les exceptions levées par Jersey et ainsi renvoyer le status approprié.