### PR TITLE
LUT-27394 - remove exception stack trace from exception mappers

### DIFF
--- a/src/java/fr/paris/lutece/plugins/rest/service/mapper/GenericUncaughtExceptionMapper.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/mapper/GenericUncaughtExceptionMapper.java
@@ -58,7 +58,7 @@ public abstract class GenericUncaughtExceptionMapper<T extends Throwable, E> imp
     @Override
     public Response toResponse( final T exception )
     {
-        AppLogService.error( "REST : Uncaught exception occured.", exception );
+        AppLogService.error( "REST : Uncaught exception occured :: {}", exception.getMessage( ) );
         return Response.status( getStatus( ) ).entity( buildEntity( exception ) ).type( getType( ) ).build( );
     }
 

--- a/src/java/fr/paris/lutece/plugins/rest/service/mapper/GenericUncaughtJerseyExceptionMapper.java
+++ b/src/java/fr/paris/lutece/plugins/rest/service/mapper/GenericUncaughtJerseyExceptionMapper.java
@@ -55,7 +55,7 @@ public abstract class GenericUncaughtJerseyExceptionMapper<T extends WebApplicat
     @Override
     public Response toResponse( final T exception )
     {
-        AppLogService.error( "REST : Uncaught Jersey exception occured.", exception );
+        AppLogService.error( "REST : Uncaught Jersey exception occured :: {}", exception.getMessage( ) );
         final Response exResponse = exception.getResponse( );
         return Response.status( exResponse.getStatus( ) ).entity( this.buildEntity( exception ) ).type( exResponse.getMediaType( ) ).build( );
     }


### PR DESCRIPTION
Related issue : https://dev.lutece.paris.fr/gitlab/bild/gestion-identite/identity-management/-/issues/422