### PR TITLE
LUT28927 - Ajout d'un filter pour api internes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>lutece-global-pom</artifactId>
         <groupId>fr.paris.lutece.tools</groupId>
-        <version>6.0.0</version>
+        <version>7.0.0</version>
     </parent>
 	
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <repository>
             <id>luteceSnapshot</id>
             <name>luteceSnapshot</name>
-            <url>http://dev.lutece.paris.fr/snapshot_repository</url>
+            <url>https://dev.lutece.paris.fr/snapshot_repository</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -33,7 +33,7 @@
         <repository>
             <id>lutece</id>
             <name>luteceRepository</name>
-            <url>http://dev.lutece.paris.fr/maven_repository</url>
+            <url>https://dev.lutece.paris.fr/maven_repository</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/webapp/WEB-INF/plugins/rest.xml
+++ b/webapp/WEB-INF/plugins/rest.xml
@@ -34,5 +34,23 @@
 			</init-param>
 			<filter-class>fr.paris.lutece.plugins.rest.service.LuteceJerseySpringServlet</filter-class>
 		</filter>
+		<filter>
+			<filter-name>Internal API Filter</filter-name>
+			<url-pattern>/internal/api/*</url-pattern>
+			<init-param>
+				<param-name>javax.ws.rs.Application</param-name>
+				<param-value>fr.paris.lutece.plugins.rest.service.LuteceApplicationResourceConfig</param-value>
+			</init-param>
+			<init-param>
+				<param-name>jersey.config.servlet.filter.contextPath</param-name>
+				<param-value>/</param-value>
+			</init-param>
+			<init-param>
+				<param-name>jersey.config.server.provider.classnames</param-name>
+				<param-value>org.glassfish.jersey.filter.LoggingFilter;
+					org.glassfish.jersey.media.multipart.MultiPartFeature</param-value>
+			</init-param>
+			<filter-class>fr.paris.lutece.plugins.rest.service.LuteceJerseySpringServlet</filter-class>
+		</filter>
 	</filters>
 </plug-in>


### PR DESCRIPTION
https://dev.lutece.paris.fr/bugtracker/issues/28927

L'objectif de cette modification est de permettre d'exposer les API internes d'une application sur un path dédié et différent du /rest/* prévu pour l'exposition des services au reste du SI.

Un cas d'utilisation rencontré dans le plugin identitystore peut -être pris pour exemple, chargement asynchrone de données dans une page:

HTML / JS:
```html
[...]

<table id="actions-by-day-table" class="table rounded rounded-3 overflow-hidden border table-condensed table-hover mb-0" style="width: 60%;">
                <tr>
                    <th onclick="sortTable(0, 'attributes-by-identities-table')">#i18n{identitystore.indicators.activities.change_type}</th>
                    <th onclick="sortTable(1, 'attributes-by-identities-table')">#i18n{identitystore.indicators.activities.change_status}</th>
                    <th onclick="sortTable(2, 'attributes-by-identities-table')">#i18n{identitystore.indicators.activities.author_type}</th>
                    <th onclick="sortTable(3, 'attributes-by-identities-table')">#i18n{identitystore.indicators.activities.client_code}</th>
                <th onclick="sortTable(4, 'attributes-by-identities-table')">#i18n{identitystore.indicators.activities.count}</th>
            </tr>
            <tr>
                <td><div class="loader"></div></td>
                <td><div class="loader"></div></td>
                <td><div class="loader"></div></td>
                <td><div class="loader"></div></td>
                <td><div class="loader"></div></td>
            </tr>
        </table>

[...]

let divDay = document.getElementById("actions-by-day-table");
        let trimmedDay = trim(divDay.innerHTML, 5);
        fetch("internal/api/identitystore/v3/indicators/count/actionsbytime?duration=1")
            .then(response => response.json())
            .then(json => divDay.innerHTML = trimmedDay + handleActionsByTimeResponse(json))
            .catch(console.error);

[...]
```

JAVA

```java
@Path( Constants.INTERNAL_API_PATH + Constants.PLUGIN_PATH + Constants.VERSION_PATH_V3 )
public class IndicatorsRestService
{

    public static final String INDICATORS_COUNT_ACTIONSBYTIME = "indicators/count/actionsbytime";
    public static final String INDICATORS_ATTRIBUTESBYIDENTITIES = "indicators/count/attributesbyidentities";
    public static final String INDICATORS_UNMERGED_NO_ATTRIBUTES = "indicators/count/unmergednoattributes";

    final static ObjectMapper objectMapper = new ObjectMapper();

    /**
     * Get all Clients
     * @return the Client
     */
    @Path(INDICATORS_COUNT_ACTIONSBYTIME)
    @GET
    @Produces( MediaType.APPLICATION_JSON )
    public Response getActionsCountByTime( @QueryParam("duration") final Integer duration )
    {

[...]
```